### PR TITLE
Fixes missing namespace

### DIFF
--- a/Examples/DataFormats/Microsoft.Analytics.Samples.Formats/Examples/example.usql
+++ b/Examples/DataFormats/Microsoft.Analytics.Samples.Formats/Examples/example.usql
@@ -11,5 +11,5 @@ REFERENCE ASSEMBLY asm;
                                  "row",
                                  new SQL.MAP<string,string> { {"qux", "c"} })
                  AS t(c string);
-OUTPUT @q TO "foo.xml" USING new Microsoft.Analytics.Samples.Xml.XmlOutputter("foo");
+OUTPUT @q TO "foo.xml" USING new Microsoft.Analytics.Samples.Formats.Xml.XmlOutputter("foo");
 


### PR DESCRIPTION
The usql example is missing the "Formats" namespace in line 14.