### PR TITLE
Allow AvroExtractor to handle empty files

### DIFF
--- a/Examples/DataFormats/Microsoft.Analytics.Samples.Formats/Avro/AvroExtractor.cs
+++ b/Examples/DataFormats/Microsoft.Analytics.Samples.Formats/Avro/AvroExtractor.cs
@@ -32,6 +32,11 @@ namespace Microsoft.Analytics.Samples.Formats.Avro
 
         public override IEnumerable<IRow> Extract(IUnstructuredReader input, IUpdatableRow output)
         {
+            if (input.Length == 0)
+            {
+                yield break;
+            }
+
             var serializer = AvroSerializer.CreateGeneric(avroSchema);
             using (var genericReader = AvroContainer.CreateGenericReader(input.BaseStream))
             {


### PR DESCRIPTION
[Event Hubs Archive](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-archive-overview#exploring-the-archive-and-working-with-avro) outputs empty files that causes `AvroExtractor` to throw an exception. Added a check for empty files before `AvroSerializer` is called.