### PR TITLE
Added unit tests for Avro Extractor and fixed issue with null column values.

### DIFF
--- a/Examples/DataFormats/Microsoft.Analytics.Samples.Formats.Tests/AvroExtractorTest.cs
+++ b/Examples/DataFormats/Microsoft.Analytics.Samples.Formats.Tests/AvroExtractorTest.cs
@@ -1,0 +1,352 @@
+﻿using Microsoft.Analytics.Interfaces;
+using Microsoft.Analytics.Types.Sql;
+using Microsoft.Analytics.UnitTest;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Analytics.Samples.Formats.Avro;
+using Microsoft.Hadoop.Avro.Container;
+using Microsoft.Hadoop.Avro;
+
+namespace Microsoft.Analytics.Samples.Formats.Tests
+{
+    [TestClass]
+    public class AvroExtractorTest
+    {
+        public AvroExtractorTest()
+        {
+            //
+            // TODO: Add constructor logic here
+            //
+        }
+
+        private TestContext testContextInstance;
+
+        /// <summary>
+        ///Gets or sets the test context which provides
+        ///information about and functionality for the current test run.
+        ///</summary>
+        public TestContext TestContext
+        {
+            get
+            {
+                return testContextInstance;
+            }
+            set
+            {
+                testContextInstance = value;
+            }
+        }
+
+        #region Additional test attributes
+        //
+        // You can use the following additional attributes as you write your tests:
+        //
+        // Use ClassInitialize to run code before running the first test in the class
+        // [ClassInitialize()]
+        // public static void MyClassInitialize(TestContext testContext) { }
+        //
+        // Use ClassCleanup to run code after all tests in a class have run
+        // [ClassCleanup()]
+        // public static void MyClassCleanup() { }
+        //
+        // Use TestInitialize to run code before running each test 
+        // [TestInitialize()]
+        // public void MyTestInitialize() { }
+        //
+        // Use TestCleanup to run code after each test has run
+        // [TestCleanup()]
+        // public void MyTestCleanup() { }
+        //
+        #endregion
+
+        public IRow SingleColumnRowGenerator<T>()
+        {
+            var foo = new USqlColumn<T>("Value");
+            var columns = new List<IColumn> { foo };
+            var schema = new USqlSchema(columns);
+            return new USqlRow(schema, null);
+        }
+
+        [TestMethod]
+        public void AvroExtractor_DatatypeInt_Extracted()
+        {
+            var output = SingleColumnRowGenerator<int>().AsUpdatable();
+            var data = new List<SingleColumnPoco<int>>
+            {
+                new SingleColumnPoco<int>() { Value = 1 },
+                new SingleColumnPoco<int>() { Value = 0 },
+            };
+
+            var result = ExecuteExtract(data);
+
+            Assert.IsTrue(result[0].Get<int>("Value") == 1);
+            Assert.IsTrue(result[1].Get<int>("Value") == 0);
+        }
+
+        [TestMethod]
+        public void AvroExtractor_DatatypeNullableInt_Extracted()
+        {
+            var output = SingleColumnRowGenerator<int?>().AsUpdatable();
+
+            var data = new List<SingleColumnPoco<int?>>
+            {
+                new SingleColumnPoco<int?>() { Value = 1 },
+                new SingleColumnPoco<int?>() { Value = null }
+            };
+
+            var result = ExecuteExtract(data);
+
+            Assert.IsTrue(result[0].Get<int?>("Value") == 1);
+            Assert.IsTrue(result[1].Get<int?>("Value") == null);
+        }
+
+        [TestMethod]
+        public void AvroExtractor_DatatypeBoolean_Extracted()
+        {
+            var data = new List<SingleColumnPoco<bool>>
+            {
+                new SingleColumnPoco<bool>() { Value = true },
+                new SingleColumnPoco<bool>() { Value = false }
+            };
+
+            var result = ExecuteExtract(data);
+
+            Assert.IsTrue(result[0].Get<bool>("Value") == true);
+            Assert.IsTrue(result[1].Get<bool>("Value") == false);
+        }
+
+        [TestMethod]
+        public void AvroExtractor_DatatypeNullableBoolean_Extracted()
+        {
+            var output = SingleColumnRowGenerator<bool?>().AsUpdatable();
+            var data = new List<SingleColumnPoco<bool?>>
+            {
+                new SingleColumnPoco<bool?>() { Value = true },
+                new SingleColumnPoco<bool?>() { Value = false },
+                new SingleColumnPoco<bool?>() { Value = null }
+            };
+
+            var result = ExecuteExtract(data);
+
+            Assert.IsTrue(result[0].Get<bool?>("Value") == true);
+            Assert.IsTrue(result[1].Get<bool?>("Value") == false);
+            Assert.IsTrue(result[2].Get<bool?>("Value") == null);
+        }
+
+        [TestMethod]
+        public void AvroExtractor_DatatypeLong_Extracted()
+        {
+            var output = SingleColumnRowGenerator<long>().AsUpdatable();
+            var data = new List<SingleColumnPoco<long>>
+            {
+                new SingleColumnPoco<long>() { Value = 9223372036854775807 },
+                new SingleColumnPoco<long>() { Value = -9223372036854775807 }
+            };
+
+            var result = ExecuteExtract(data);
+
+            Assert.IsTrue(result[0].Get<long>("Value") == 9223372036854775807);
+            Assert.IsTrue(result[1].Get<long>("Value") == -9223372036854775807);
+        }
+
+        [TestMethod]
+        public void AvroExtractor_DatatypeNullableLong_Extracted()
+        {
+            var output = SingleColumnRowGenerator<long?>().AsUpdatable();
+            var data = new List<SingleColumnPoco<long?>>
+            {
+                new SingleColumnPoco<long?>() { Value = 9223372036854775807 },
+                new SingleColumnPoco<long?>() { Value = -9223372036854775807 },
+                new SingleColumnPoco<long?>() { Value = null }
+            };
+
+            var result = ExecuteExtract(data);
+
+            Assert.IsTrue(result[0].Get<long?>("Value") == 9223372036854775807);
+            Assert.IsTrue(result[1].Get<long?>("Value") == -9223372036854775807);
+            Assert.IsTrue(result[2].Get<long?>("Value") == null);
+        }
+
+        [TestMethod]
+        public void AvroExtractor_DatatypeFloat_Extracted()
+        {
+            var output = SingleColumnRowGenerator<float>().AsUpdatable();
+            var data = new List<SingleColumnPoco<float>>
+            {
+                new SingleColumnPoco<float>() { Value = 3.5F},
+                new SingleColumnPoco<float>() { Value = 0 }
+            };
+
+            var result = ExecuteExtract(data);
+
+            Assert.IsTrue(result[0].Get<float>("Value") == 3.5F);
+            Assert.IsTrue(result[1].Get<float>("Value") == 0);
+        }
+
+        [TestMethod]
+        public void AvroExtractor_DatatypeNullableFloat_Extracted()
+        {
+            var output = SingleColumnRowGenerator<float?>().AsUpdatable();
+            var data = new List<SingleColumnPoco<float?>>
+            {
+                new SingleColumnPoco<float?>() { Value = 3.5F},
+                new SingleColumnPoco<float?>() { Value = 0 },
+                new SingleColumnPoco<float?>() { Value = null }
+            };
+
+            var result = ExecuteExtract(data);
+
+            Assert.IsTrue(result[0].Get<float?>("Value") == 3.5F);
+            Assert.IsTrue(result[1].Get<float?>("Value") == 0);
+            Assert.IsTrue(result[2].Get<float?>("Value") == null);
+        }
+
+        [TestMethod]
+        public void AvroExtractor_DatatypeDouble_Extracted()
+        {
+            var output = SingleColumnRowGenerator<double>().AsUpdatable();
+            var data = new List<SingleColumnPoco<double>>
+            {
+                new SingleColumnPoco<double>() { Value = 3D},
+                new SingleColumnPoco<double>() { Value = 0 }
+            };
+
+            var result = ExecuteExtract(data);
+
+            Assert.IsTrue(result[0].Get<double>("Value") == 3D);
+            Assert.IsTrue(result[1].Get<double>("Value") == 0);
+        }
+
+        [TestMethod]
+        public void AvroExtractor_DatatypeNullableDouble_Extracted()
+        {
+            var output = SingleColumnRowGenerator<double?>().AsUpdatable();
+            var data = new List<SingleColumnPoco<double?>>
+            {
+                new SingleColumnPoco<double?>() { Value = 3D},
+                new SingleColumnPoco<double?>() { Value = 0 },
+                new SingleColumnPoco<double?>() { Value = null }
+            };
+
+            var result = ExecuteExtract(data);
+
+            Assert.IsTrue(result[0].Get<double?>("Value") == 3D);
+            Assert.IsTrue(result[1].Get<double?>("Value") == 0);
+            Assert.IsTrue(result[2].Get<double?>("Value") == null);
+        }
+
+        [TestMethod]
+        public void AvroExtractor_DatatypeByte_Extracted()
+        {
+            var output = SingleColumnRowGenerator<byte[]>().AsUpdatable();
+            byte[] bytes = { 2, 4, 6 };
+            var data = new List<SingleColumnPoco<byte[]>>
+            {
+                new SingleColumnPoco<byte[]>() { Value = bytes }
+            };
+
+            var result = ExecuteExtract(data);
+
+            Assert.IsTrue(result[0].Get<byte[]>("Value")[0] == 2);
+        }
+
+        [TestMethod]
+        public void AvroExtractor_DatatypeNullableByte_Extracted()
+        {
+            var output = SingleColumnRowGenerator<byte[]>().AsUpdatable();
+            byte[] bytes = { 2, 4, 6 };
+            var data = new List<SingleColumnPoco<byte[]>>
+            {
+                new SingleColumnPoco<byte[]>() { Value = bytes },
+                new SingleColumnPoco<byte[]>() { Value = null }
+            };
+
+            var result = ExecuteExtract(data);
+
+            Assert.IsTrue(result[0].Get<byte[]>("Value")[0] == 2);
+            Assert.IsTrue(result[1].Get<byte[]>("Value") == null);
+        }
+
+        [TestMethod]
+        public void AvroExtractor_DatatypeString_Extracted()
+        {
+            var output = SingleColumnRowGenerator<string>().AsUpdatable();
+            var data = new List<SingleColumnPoco<string>>
+            {
+                new SingleColumnPoco<string>() { Value = "asdf" },
+                new SingleColumnPoco<string>() { Value = "" }
+            };
+
+            var result = ExecuteExtract(data);
+
+            Assert.IsTrue(result[0].Get<string>("Value") == "asdf");
+            Assert.IsTrue(result[1].Get<string>("Value") == "");
+        }
+
+        [TestMethod]
+        public void AvroExtractor_DatatypeNullableString_Extracted()
+        {
+            var output = SingleColumnRowGenerator<string>().AsUpdatable();
+
+            var data = new List<SingleColumnPoco<string>>
+            {
+                new SingleColumnPoco<string>() { Value = "asdf" },
+                new SingleColumnPoco<string>() { Value = null }
+            };
+
+            var result = ExecuteExtract(data);
+
+            Assert.IsTrue(result[0].Get<string>("Value") == "asdf");
+            Assert.IsTrue(result[1].Get<string>("Value") == null);
+        }
+
+        [TestMethod]
+        public void AvroExtractor_EmptyFile_ReturnNoRow()
+        {
+            var output = SingleColumnRowGenerator<string>().AsUpdatable();
+
+            var data = new List<SingleColumnPoco<string>>();
+
+            var result = ExecuteExtract(data);
+
+            Assert.IsTrue(result.Count == 0);
+        }
+
+        private IList<IRow> ExecuteExtract<T>(List<SingleColumnPoco<T>> data)
+        {
+            var output = SingleColumnRowGenerator<T>().AsUpdatable();
+
+            using (var dataStream = new MemoryStream())
+            {
+                serializeAvro(dataStream, data);
+
+                var schema = getAvroSchema<SingleColumnPoco<T>>();
+
+                var reader = new USqlStreamReader(dataStream);
+                var extractor = new AvroExtractor(schema);
+                return extractor.Extract(reader, output).ToList();
+            }
+        }
+
+        private void serializeAvro<T>(MemoryStream dataStream, List<T> data)
+        {
+            using (var avroWriter = AvroContainer.CreateWriter<T>(dataStream, Codec.Deflate))
+            {
+                using (var seqWriter = new SequentialWriter<T>(avroWriter, 24))
+                {
+                    data.ForEach(seqWriter.Write);
+                }
+            }
+        }
+
+        private string getAvroSchema<T>()
+        {
+            var avroSerializer = AvroSerializer.Create<T>();
+            return avroSerializer.ReaderSchema.ToString();
+        }
+    }
+}

--- a/Examples/DataFormats/Microsoft.Analytics.Samples.Formats.Tests/Microsoft.Analytics.Samples.Formats.Tests.csproj
+++ b/Examples/DataFormats/Microsoft.Analytics.Samples.Formats.Tests/Microsoft.Analytics.Samples.Formats.Tests.csproj
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{67D27E86-5C4D-418F-8A1C-B37997566A6E}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Microsoft.Analytics.Samples.Formats.Tests</RootNamespace>
+    <AssemblyName>Microsoft.Analytics.Samples.Formats.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{4D4E14FB-86F2-46A5-8BFB-41569A68D9E8};{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>USQLUnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Hadoop.Avro">
+      <HintPath>..\..\..\..\..\..\..\Temp\Avro\Assemblies\Microsoft.Hadoop.Avro.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="Microsoft.Analytics.Interfaces" />
+    <Reference Include="Microsoft.Analytics.Types" />
+    <Reference Include="Microsoft.Analytics.UnitTest" />
+    <Reference Include="System.Runtime.Serialization" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="AvroExtractorTest.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SingleColumnPoco.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Analytics.Samples.Formats\Microsoft.Analytics.Samples.Formats.csproj">
+      <Project>{1b3e7106-6d16-4b96-87c5-f15e18ffc08f}</Project>
+      <Name>Microsoft.Analytics.Samples.Formats</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Examples/DataFormats/Microsoft.Analytics.Samples.Formats.Tests/Properties/AssemblyInfo.cs
+++ b/Examples/DataFormats/Microsoft.Analytics.Samples.Formats.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Microsoft.Analytics.Samples.Formats.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Microsoft.Analytics.Samples.Formats.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("67d27e86-5c4d-418f-8a1c-b37997566a6e")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Examples/DataFormats/Microsoft.Analytics.Samples.Formats.Tests/SingleColumnPoco.cs
+++ b/Examples/DataFormats/Microsoft.Analytics.Samples.Formats.Tests/SingleColumnPoco.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Runtime.Serialization;
+using Microsoft.Hadoop.Avro;
+
+namespace Microsoft.Analytics.Samples.Formats.Tests
+{
+    [DataContract(Name = "Foo", Namespace = "Microsoft.Analytics.Samples.Formats.Tests")]
+    public class SingleColumnPoco<T>
+    {
+        [DataMember]
+        [NullableSchema]
+        public T Value { get; set; }
+
+    }
+}

--- a/Examples/DataFormats/Microsoft.Analytics.Samples.Formats/Avro/AvroExtractor.cs
+++ b/Examples/DataFormats/Microsoft.Analytics.Samples.Formats/Avro/AvroExtractor.cs
@@ -32,22 +32,24 @@ namespace Microsoft.Analytics.Samples.Formats.Avro
 
         public override IEnumerable<IRow> Extract(IUnstructuredReader input, IUpdatableRow output)
         {
-            if (input.Length == 0)
-            {
-                yield break;
-            }
-
             var serializer = AvroSerializer.CreateGeneric(avroSchema);
             using (var genericReader = AvroContainer.CreateGenericReader(input.BaseStream))
             {
                 using (var reader = new SequentialReader<dynamic>(genericReader))
-                { 
+                {
                     foreach (var obj in reader.Objects)
                     {
                         foreach (var column in output.Schema)
-                        {                            
-                            output.Set(column.Name, obj[column.Name]);
-                        }         
+                        {
+                            if (obj[column.Name] != null)
+                            {
+                                output.Set(column.Name, obj[column.Name]);
+                            }
+                            else
+                            {
+                                output.Set<object>(column.Name, null);
+                            }
+                        }
 
                         yield return output.AsReadOnly();
                     }

--- a/Examples/DataFormats/Microsoft.Analytics.Samples.Formats/Microsoft.Analytics.Samples.Formats.csproj
+++ b/Examples/DataFormats/Microsoft.Analytics.Samples.Formats/Microsoft.Analytics.Samples.Formats.csproj
@@ -37,11 +37,11 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Hadoop.Avro">
-      <HintPath>..\packages\Microsoft.Hadoop.Avro.1.5.6\lib\net45\Microsoft.Hadoop.Avro.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\Temp\Avro\Assemblies\Microsoft.Hadoop.Avro.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\Temp\Avro\Assemblies\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -62,9 +62,6 @@
     <Compile Include="Xml\XmlExtractor.cs" />
     <Compile Include="Xml\XmlOutputter.cs" />
     <Compile Include="Xml\XPath.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Examples/DataFormats/Microsoft.Analytics.Samples.Formats/packages.config
+++ b/Examples/DataFormats/Microsoft.Analytics.Samples.Formats/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
-  <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
-</packages>

--- a/Examples/DataFormats/Microsoft.Analytics.Samples.sln
+++ b/Examples/DataFormats/Microsoft.Analytics.Samples.sln
@@ -1,19 +1,31 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Analytics.Samples.Formats", "Microsoft.Analytics.Samples.Formats\Microsoft.Analytics.Samples.Formats.csproj", "{1B3E7106-6D16-4B96-87C5-F15E18FFC08F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Analytics.Samples.Formats.Tests", "Microsoft.Analytics.Samples.Formats.Tests\Microsoft.Analytics.Samples.Formats.Tests.csproj", "{67D27E86-5C4D-418F-8A1C-B37997566A6E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{1B3E7106-6D16-4B96-87C5-F15E18FFC08F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1B3E7106-6D16-4B96-87C5-F15E18FFC08F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1B3E7106-6D16-4B96-87C5-F15E18FFC08F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1B3E7106-6D16-4B96-87C5-F15E18FFC08F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{67D27E86-5C4D-418F-8A1C-B37997566A6E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{67D27E86-5C4D-418F-8A1C-B37997566A6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{67D27E86-5C4D-418F-8A1C-B37997566A6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{67D27E86-5C4D-418F-8A1C-B37997566A6E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {CDD298CC-9696-44BC-9CED-128BEDE1DCE8}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Fixed issue when column value is null:
> The type arguments for method 'Microsoft.Analytics.Interfaces.IUpdatableRow.Set<T>(string, T)' cannot be inferred from the usage. Try specifying the type arguments explicitly." The details includes more information including any inner exceptions and the stack trace where the exception was raised.

Created unit tests to test primitive datatypes, null columns and empty avro files.
Upgraded project to VS2017. 