### PR TITLE
AvroExtractor.cs, change to one row per record

### DIFF
--- a/Examples/DataFormats/Microsoft.Analytics.Samples.Formats/Avro/AvroExtractor.cs
+++ b/Examples/DataFormats/Microsoft.Analytics.Samples.Formats/Avro/AvroExtractor.cs
@@ -57,9 +57,9 @@ namespace Microsoft.Analytics.Samples.Formats.ApacheAvro
                         {
                             output.Set<object>(column.Name, null);
                         }
-
-                        yield return output.AsReadOnly();
                     }
+                    
+                    yield return output.AsReadOnly();
                 }
             }
         }


### PR DESCRIPTION
I propose that the AvroExtractor returns one row with all columns for a record, rather than one new row for each column in record.