### PR TITLE
Enable atomic file processing on MultiLevelJsonExtractor

### DIFF
--- a/Examples/DataFormats/Microsoft.Analytics.Samples.Formats/Json/MultiLevelJsonExtractor.cs
+++ b/Examples/DataFormats/Microsoft.Analytics.Samples.Formats/Json/MultiLevelJsonExtractor.cs
@@ -9,6 +9,7 @@ using Microsoft.Analytics.Samples.Formats.Json.Exceptions;
 
 namespace Microsoft.Analytics.Samples.Formats.Json
 {
+    [SqlUserDefinedExtractor(AtomicFileProcessing=true)]
     public class MultiLevelJsonExtractor : JsonExtractor
     {
         private string[] jsonPaths;


### PR DESCRIPTION
Explicitly enable atomic file processing on MultiLevelJsonExtractor, because
USQL ignores the inherited attribute and will still split files greater than
1 gigabyte.